### PR TITLE
Use uint8 instead of Bytef in non-compression code path

### DIFF
--- a/gpdb.c
+++ b/gpdb.c
@@ -222,7 +222,7 @@ Dump_AppendOnlyStorage_ContentInfo(uint8 *headerPtr,
 								   AppendOnlyStorageReadCurrent *blkHdr)
 {
 	DatumStreamBlock_Orig *contentPtr;
-	Bytef	   *uncompressedDatum = NULL;
+	uint8 	   *uncompressedDatum = NULL;
 	bool		success = true;
 
 	printf("\n\t<AO Content Info> -----");


### PR DESCRIPTION
Bytef is only provided by one of the compression library (zlib, zstd or quilz). It's possible that none of the library is present. We want to cover that case. So we should use a general data type instead of something dependent on optional libraries.

Fix #1.